### PR TITLE
Add target total pruned value to wandb config

### DIFF
--- a/pruning/architecture/utility/summary.py
+++ b/pruning/architecture/utility/summary.py
@@ -111,6 +111,9 @@ def create_wandb_run(cfg: MainConfig, group_name: str, run_name: str) -> wandb.s
     """
 
     config = strip_underscore_keys(OmegaConf.to_container(cfg, resolve=True))
+    config["target_total_pruned"] = (
+        config["pruning"]["iteration_rate"] * config["pruning"]["iterations"]
+    )
 
     if cfg._wandb.logging:
         wandb_run = wandb.init(

--- a/pruning/architecture/utility/training.py
+++ b/pruning/architecture/utility/training.py
@@ -72,7 +72,7 @@ def validate_epoch(
 
     module.eval()
     metrics = {name: 0.0 for name in metrics_functions.keys()}
-    metrics["validation_loss"] = 0.0
+    metrics["validation loss"] = 0.0
 
     with torch.no_grad():
         for X, labels in valid_dl:
@@ -81,7 +81,7 @@ def validate_epoch(
             pred = module(X)
             loss = loss_function(pred, labels)
 
-            metrics["validation_loss"] += loss.item()
+            metrics["validation loss"] += loss.item()
             for name, func in metrics_functions.items():
                 metrics[name] += func(pred, labels)
 


### PR DESCRIPTION
Add target total pruned value to wandb config, which will enable easy comparison between runs.