### PR TITLE
Add efficientnet cifar support

### DIFF
--- a/pruning/architecture/construct_dataset.py
+++ b/pruning/architecture/construct_dataset.py
@@ -4,15 +4,29 @@ from torch.utils.data import DataLoader, Dataset
 from torchvision import datasets, transforms
 
 
-def get_cifar10(path: str, download: bool) -> tuple[Dataset, Dataset, Dataset]:
-    test_transform = transforms.Compose(
-        [
-            transforms.ToTensor(),
-            transforms.Normalize(
-                mean=[0.4914, 0.4822, 0.4465], std=[0.2023, 0.1994, 0.2010]
-            ),  # normalize the cifar10 images
-        ]
-    )
+def get_cifar10(
+    path: str, download: bool, resize_value: int | None = None
+) -> tuple[Dataset, Dataset]:
+    """Constructs the CIFAR10 dataset.
+
+    Args:
+        path (str): Path to the dataset.
+        download (bool): Should the dataset be downloaded.
+        resize_value (int | None, optional): Value to resize the images to. Defaults to None.
+
+    Returns:
+        tuple[Dataset, Dataset, Dataset]: Tuple of train and test datasets.
+    """
+
+    common_transformations = [
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.4914, 0.4822, 0.4465], std=[0.2023, 0.1994, 0.2010]),
+    ]
+
+    if resize_value is not None:
+        common_transformations.insert(0, transforms.Resize((resize_value, resize_value)))
+
+    test_transform = transforms.Compose(common_transformations)
 
     train_transform = transforms.Compose(
         [
@@ -39,13 +53,29 @@ def get_cifar10(path: str, download: bool) -> tuple[Dataset, Dataset, Dataset]:
     return train_dataset, validate_dataset
 
 
-def get_cifar100(path: str, download: bool) -> tuple[Dataset, Dataset]:
-    test_transform = transforms.Compose(
-        [
-            transforms.ToTensor(),
-            transforms.Normalize((0.5074, 0.4867, 0.4411), (0.2011, 0.1987, 0.2025)),
-        ]
-    )
+def get_cifar100(
+    path: str, download: bool, resize_value: int | None = None
+) -> tuple[Dataset, Dataset]:
+    """Constructs the CIFAR100 dataset.
+
+    Args:
+        path (str): Path to the dataset.
+        download (bool): Should the dataset be downloaded.
+        resize_value (int | None, optional): Value to resize the images to. Defaults to None.
+
+    Returns:
+        tuple[Dataset, Dataset]: Tuple of train and test datasets.
+    """
+
+    common_transformations = [
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.5071, 0.4867, 0.4408], std=[0.2675, 0.2565, 0.2761]),
+    ]
+
+    if resize_value is not None:
+        common_transformations.insert(0, transforms.Resize((resize_value, resize_value)))
+
+    test_transform = transforms.Compose(common_transformations)
 
     train_transform = transforms.Compose(
         [
@@ -72,11 +102,12 @@ def get_cifar100(path: str, download: bool) -> tuple[Dataset, Dataset]:
     return train_dataset, validate_dataset
 
 
-def get_imagenet1k(path: str) -> tuple[Dataset, Dataset]:
+def get_imagenet1k(path: str, resize_value: int | None = None) -> tuple[Dataset, Dataset]:
     """Constructs the ImageNet1K dataset.
 
     Args:
         path (str): Path to the dataset.
+        resize_value (int | None): The size to resize the images to. Defaults to None.
 
     Returns:
         tuple[Dataset, Dataset]: Train and validation datasets.
@@ -119,11 +150,15 @@ def get_dataset(
 ) -> tuple[torch.utils.data.Dataset, torch.utils.data.Dataset]:
     match cfg.dataset.name.lower():
         case "cifar10":
-            return get_cifar10(cfg.dataset._path, cfg.dataset._download)
+            return get_cifar10(
+                cfg.dataset._path, cfg.dataset._download, resize_value=cfg.dataset.resize_value
+            )
         case "cifar100":
-            return get_cifar100(cfg.dataset._path, cfg.dataset._download)
+            return get_cifar100(
+                cfg.dataset._path, cfg.dataset._download, resize_value=cfg.dataset.resize_value
+            )
         case "imagenet1k":
-            return get_imagenet1k(cfg.dataset._path)
+            return get_imagenet1k(cfg.dataset._path, resize_value=cfg.dataset.resize_value)
         case _:
             raise ValueError(f"Unknown dataset: {cfg.dataset.name}")
 

--- a/pruning/architecture/construct_model.py
+++ b/pruning/architecture/construct_model.py
@@ -6,9 +6,7 @@ from torch import nn
 
 def register_models() -> None:
     """Register all the models in the timm registry by importing the module"""
-    from architecture.models import lenet_cifar  # noqa: F401, I001
-    from architecture.models import resnet_cifar  # noqa: F401
-    from architecture.models import resnet_imagenet  # noqa: F401
+    import architecture.models  # noqa: F401
 
 
 def construct_model(cfg: MainConfig) -> nn.Module:

--- a/pruning/architecture/models/__init__.py
+++ b/pruning/architecture/models/__init__.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+from pathlib import Path
+from pkgutil import iter_modules
+
+# get the current package name
+package_name = __name__
+
+# get the path of the current package
+package_path = Path(__file__).parent
+
+# iterate over all modules in the current package
+for _, module_name, _ in iter_modules([package_path]):
+    # import the module
+    import_module(f"{package_name}.{module_name}")

--- a/pruning/architecture/models/efficientnetv2s.py
+++ b/pruning/architecture/models/efficientnetv2s.py
@@ -1,0 +1,9 @@
+from timm.models.registry import register_model
+from torchvision import models
+
+
+@register_model
+def efficientnetv2s(num_classes: int, **kwargs):
+    model = models.efficientnet_v2_s(num_classes=num_classes)
+
+    return model

--- a/pruning/architecture/pruning_loop.py
+++ b/pruning/architecture/pruning_loop.py
@@ -18,7 +18,7 @@ from wandb.sdk.wandb_run import Run
 
 logger = logging.getLogger(__name__)
 # TODO: somehow add the pruning classes to Hydra config
-PRUNING_CLASSES = (nn.Linear, nn.Conv2d, nn.BatchNorm2d)
+PRUNING_CLASSES = (nn.Linear, nn.Conv2d)
 
 
 def start_pruning_experiment(cfg: MainConfig, out_directory: Path) -> None:

--- a/pruning/config/datasets.py
+++ b/pruning/config/datasets.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from omegaconf import MISSING
 
@@ -6,6 +7,7 @@ from omegaconf import MISSING
 @dataclass
 class BaseDataset:
     name: str = MISSING
+    resize_value: Optional[int] = None
     _path: str = MISSING
     _num_classes: int = MISSING
     _download: bool = False


### PR DESCRIPTION
Change model imports in the models folder to automatically import all models which are definied in .py files in this folder. (Needed for model_register).
Add support for Cifar for efficientnet.
Include option in config to rescale the images in the dataset.