### PR TITLE
replace the global unstructured with modified version

### DIFF
--- a/pruning/architecture/pruning_methods/methods.py
+++ b/pruning/architecture/pruning_methods/methods.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 from typing import Callable, Iterable, Iterator
 
-from architecture.utility.pruning import calculate_parameters_amount
+from architecture.utility.pruning import calculate_parameters_amount, global_unstructured_modified
 from config.methods import BasePruningMethodConfig, GlobalL1UnstructuredConfig, LnStructuredConfig
 import torch
 from torch import nn
@@ -69,7 +69,7 @@ def global_l1_unstructured(
 
     amount_to_prune = int(calculate_parameters_amount(parameters_to_prune) * next(pruning_values))
 
-    prune.global_unstructured(
+    global_unstructured_modified(
         parameters_to_prune,
         pruning_method=prune.L1Unstructured,
         amount=amount_to_prune,

--- a/pruning/architecture/utility/pruning.py
+++ b/pruning/architecture/utility/pruning.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from config.main_config import MainConfig
 import torch
 import torch.nn as nn
-
+import torch.nn.utils.prune as prune
 
 def get_parameters_to_prune(
     model: nn.Module, types_to_prune: Iterable[nn.Module]
@@ -228,3 +228,75 @@ def validate_manual_pruning(
         f"Invalid length of the pruning step: {len(pruning_steps[0])}\n"
         f"should be equal to the number of layers to prune: {num_layers}"
     )
+
+
+def global_unstructured_modified(parameters, pruning_method, importance_scores=None, **kwargs):
+    r"""
+        Modified version of torch.nn.utils.prune.global_l1_unstructured.
+        Removes the hooks with masks to reduce memory usage.
+    """
+    # ensure parameters is a list or generator of tuples
+    if not isinstance(parameters, Iterable):
+        raise TypeError("global_unstructured(): parameters is not an Iterable")
+
+    importance_scores = importance_scores if importance_scores is not None else {}
+    if not isinstance(importance_scores, dict):
+        raise TypeError("global_unstructured(): importance_scores must be of type dict")
+
+    # flatten importance scores to consider them all at once in global pruning
+    relevant_importance_scores = torch.nn.utils.parameters_to_vector(
+        [
+            importance_scores.get((module, name), getattr(module, name))
+            for (module, name) in parameters
+        ]
+    )
+    # similarly, flatten the masks (if they exist), or use a flattened vector
+    # of 1s of the same dimensions as t
+    default_mask = torch.nn.utils.parameters_to_vector(
+        [
+            getattr(module, name + "_mask", torch.ones_like(getattr(module, name)))
+            for (module, name) in parameters
+        ]
+    )
+
+    # use the canonical pruning methods to compute the new mask, even if the
+    # parameter is now a flattened out version of `parameters`
+    container = prune.PruningContainer()
+    container._tensor_name = "temp"  # to make it match that of `method`
+    method = pruning_method(**kwargs)
+    method._tensor_name = "temp"  # to make it match that of `container`
+    if method.PRUNING_TYPE != "unstructured":
+        raise TypeError(
+            'Only "unstructured" PRUNING_TYPE supported for '
+            f"the `pruning_method`. Found method {pruning_method} of type {method.PRUNING_TYPE}"
+        )
+
+    container.add_pruning_method(method)
+
+    # use the `compute_mask` method from `PruningContainer` to combine the
+    # mask computed by the new method with the pre-existing mask
+    final_mask = container.compute_mask(relevant_importance_scores, default_mask)
+
+    # Pointer for slicing the mask to match the shape of each parameter
+    pointer = 0
+    for module, name in parameters:
+
+        param = getattr(module, name)
+        # The length of the parameter
+        num_param = param.numel()
+        # Slice the mask, reshape it
+        param_mask = final_mask[pointer : pointer + num_param].view_as(param)
+        # Assign the correct pre-computed mask to each parameter and add it
+        # to the forward_pre_hooks like any other pruning method
+        prune.custom_from_mask(module, name, mask=param_mask)
+        
+        for k in list(module._forward_pre_hooks):
+            hook = module._forward_pre_hooks[k]
+            if isinstance(hook, prune.PruningContainer):
+                if isinstance(hook[-1], prune.CustomFromMask):
+                    hook[-1].mask = None
+            elif isinstance(hook, prune.CustomFromMask):
+                hook.mask = None
+
+        # Increment the pointer to continue slicing the final_mask
+        pointer += num_param

--- a/pruning/config/main_config.py
+++ b/pruning/config/main_config.py
@@ -37,7 +37,7 @@ class Pruning:
     scheduler: BasePruningSchedulerConfig = MISSING
     method: BasePruningMethodConfig = MISSING
     finetune_epochs: int = MISSING
-    _checkpoints_interval: Interval = field(default_factory=lambda: Interval(0.5, 1.0))
+    _checkpoints_interval: Interval = field(default_factory=lambda: Interval(0.0, 1.0))
 
 
 @dataclass


### PR DESCRIPTION
Replace the pytorch.prune global_l1_unstructured method with our own slightly modified version which removes the old masks from prehooks.